### PR TITLE
Changed Ferris image path inside README.md from  photos/Rust-Ferris.jpg to photos/Rust-Ferris.JPG

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ There will be two sources of the patterns:
 
 ### Ferris from Rust
 
-![Ferris from Rust](photos/Rust-Ferris.jpg)
+![Ferris from Rust](photos/Rust-Ferris.JPG)
 
 - [Blogger Link](https://www.softieslinzi.art/2023/01/ferris-from-rust.html)
 - [Ravelry PDF](https://www.ravelry.com/patterns/library/ferris-from-rust)


### PR DESCRIPTION
In this pull request I fixed the Ferris image path not having the correct extension (jpg instead of JPG) inside README.md

It was making the image not rendering

Previous look: 
![image](https://github.com/user-attachments/assets/c69c1bca-eea4-4046-a0c5-3225371a77cd)

![image](https://github.com/user-attachments/assets/01c620df-c988-4369-8253-0cb526e5228e)

Current look: 
![image](https://github.com/user-attachments/assets/7c9dd156-9c36-4005-b263-20c35c65557d)

Have a great day!
